### PR TITLE
reset trace mask value in freeproc(struct proc *p)

### DIFF
--- a/kernel/proc.c
+++ b/kernel/proc.c
@@ -169,6 +169,7 @@ freeproc(struct proc *p)
   p->killed = 0;
   p->xstate = 0;
   p->state = UNUSED;
+  p->mask = 0;     // reset trace mask value (which is used in syscall 'trace')
 }
 
 // Create a user page table for a given process, with no user memory,


### PR DESCRIPTION
A small potential bug here? Should reset trace mask value to 0 when calling freeproc(p).